### PR TITLE
Tests no longer print to console

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,39 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "prettier/@typescript-eslint",
+    "plugin:prettier/recommended"
+  ],
+  "plugins": [
+    "@typescript-eslint",
+    "header"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/interface-name-prefix": [
+      "error",
+      {
+        "prefixWithI": "always"
+      }
+    ],
+    "header/header": [
+      2,
+      "block",
+      [
+        "",
+        {
+          "pattern": "^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$",
+          "template": " * Copyright (c) 2020, salesforce.com, inc."
+        },
+        " * All rights reserved.",
+        " * SPDX-License-Identifier: BSD-3-Clause",
+        " * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause",
+        " "
+      ]
+    ]
+  }
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,9 @@
+{
+  "file": "test/setup.ts",
+  "forbidOnly": true,
+  "require": [
+    "source-map-support/register",
+    "ts-node/register"
+  ],
+  "colors": true
+}

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": "@istanbuljs/nyc-config-typescript",
+  "include": [
+    "src/**/*.ts"
+  ],
+  "reporter": [
+    "lcov",
+    "text"
+  ],
+  "extension": [
+    ".ts"
+  ],
+  "all": true,
+  "check-coverage": true,
+  "branches": 80,
+  "functions": 80,
+  "lines": 80,
+  "statements": -10,
+  "per-file": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -784,6 +784,16 @@
       "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
       "dev": true
     },
+    "@types/glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+      "dev": true,
+      "requires": {
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/graphlib": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/@types/graphlib/-/graphlib-2.1.7.tgz",
@@ -840,6 +850,12 @@
       "version": "4.14.161",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.161.tgz",
       "integrity": "sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==",
+      "dev": true
+    },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/mocha": {
@@ -957,6 +973,12 @@
           "dev": true
         }
       }
+    },
+    "@ungap/promise-all-settled": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
+      "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
+      "dev": true
     },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -1739,19 +1761,19 @@
       "integrity": "sha1-mJdNx+0e5MYin44wX6cxOmiFp/I="
     },
     "chokidar": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-      "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.3.tgz",
+      "integrity": "sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.1",
+        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.2.0"
+        "readdirp": "~3.5.0"
       }
     },
     "ci-info": {
@@ -2110,15 +2132,6 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
       "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg=="
     },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
-    },
     "degenerator": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
@@ -2254,6 +2267,18 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "detect-indent": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.0.0.tgz",
+      "integrity": "sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==",
+      "dev": true
+    },
+    "detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
     },
     "diff": {
@@ -2448,36 +2473,6 @@
       "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.17.6",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
       }
     },
     "es6-error": {
@@ -3130,13 +3125,10 @@
       }
     },
     "flat": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
-      "dev": true,
-      "requires": {
-        "is-buffer": "~2.0.3"
-      }
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true
     },
     "flat-cache": {
       "version": "2.0.1",
@@ -3316,12 +3308,6 @@
         }
       }
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
@@ -3399,6 +3385,12 @@
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
+    },
+    "git-hooks-list": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+      "integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
+      "dev": true
     },
     "glob": {
       "version": "7.1.6",
@@ -3500,25 +3492,10 @@
         "through2": "^2.0.3"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-symbols": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
-      "dev": true
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -3847,18 +3824,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-buffer": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-      "dev": true
-    },
-    "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
-      "dev": true
-    },
     "is-ci": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
@@ -3866,12 +3831,6 @@
       "requires": {
         "ci-info": "^2.0.0"
       }
-    },
-    "is-date-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
-      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==",
-      "dev": true
     },
     "is-deflate": {
       "version": "1.0.0",
@@ -3949,14 +3908,11 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
       "integrity": "sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg=="
     },
-    "is-regex": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true
     },
     "is-regexp": {
       "version": "1.0.0",
@@ -3968,15 +3924,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
-    },
-    "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.1"
-      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -5279,43 +5226,38 @@
       }
     },
     "mocha": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
-      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-8.2.1.tgz",
+      "integrity": "sha512-cuLBVfyFfFqbNR0uUKbDGXKGk+UDFe6aR4os78XIrMQpZl/nv7JYHcvP5MFIAb374b2zFXsdgEGwmzMtP0Xg8w==",
       "dev": true,
       "requires": {
-        "ansi-colors": "3.2.3",
+        "@ungap/promise-all-settled": "1.1.2",
+        "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.3.0",
-        "debug": "3.2.6",
-        "diff": "3.5.0",
-        "escape-string-regexp": "1.0.5",
-        "find-up": "3.0.0",
-        "glob": "7.1.3",
+        "chokidar": "3.4.3",
+        "debug": "4.2.0",
+        "diff": "4.0.2",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.1.6",
         "growl": "1.10.5",
         "he": "1.2.0",
-        "js-yaml": "3.13.1",
-        "log-symbols": "3.0.0",
+        "js-yaml": "3.14.0",
+        "log-symbols": "4.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.5",
-        "ms": "2.1.1",
-        "node-environment-flags": "1.0.6",
-        "object.assign": "4.1.0",
-        "strip-json-comments": "2.0.1",
-        "supports-color": "6.0.0",
-        "which": "1.3.1",
+        "ms": "2.1.2",
+        "nanoid": "3.1.12",
+        "serialize-javascript": "5.0.1",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "7.2.0",
+        "which": "2.0.2",
         "wide-align": "1.1.3",
+        "workerpool": "6.0.2",
         "yargs": "13.3.2",
         "yargs-parser": "13.1.2",
-        "yargs-unparser": "1.6.0"
+        "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "ansi-colors": {
-          "version": "3.2.3",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-          "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
-          "dev": true
-        },
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
@@ -5364,19 +5306,13 @@
           "dev": true
         },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
-        },
-        "diff": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-          "dev": true
         },
         "emoji-regex": {
           "version": "7.0.3",
@@ -5384,34 +5320,21 @@
           "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
           "dev": true
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
         "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
           }
         },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -5419,55 +5342,32 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "^5.0.0"
           }
         },
-        "log-symbols": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-          "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+        "p-limit": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+          "integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2"
+            "p-try": "^2.0.0"
           }
-        },
-        "ms": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-          "dev": true
         },
         "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "^3.0.2"
           }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
         },
         "string-width": {
           "version": "3.1.0",
@@ -5489,13 +5389,28 @@
             "ansi-regex": "^4.1.0"
           }
         },
+        "strip-json-comments": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+          "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+          "dev": true
+        },
         "supports-color": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-          "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         },
         "wrap-ansi": {
@@ -5531,6 +5446,51 @@
             "which-module": "^2.0.0",
             "y18n": "^4.0.0",
             "yargs-parser": "^13.1.2"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^3.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+              "dev": true,
+              "requires": {
+                "p-locate": "^3.0.0",
+                "path-exists": "^3.0.0"
+              }
+            },
+            "p-limit": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+              "dev": true,
+              "requires": {
+                "p-try": "^2.0.0"
+              }
+            },
+            "p-locate": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.0.0"
+              }
+            },
+            "path-exists": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+              "dev": true
+            }
           }
         },
         "yargs-parser": {
@@ -5554,6 +5514,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
+    },
+    "nanoid": {
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.12.tgz",
+      "integrity": "sha512-1qstj9z5+x491jfiC4Nelk+f8XBad7LN20PmyWINJEMRSf3wcAjAWysw1qaA8z6NSKe2sjq1hRSDpBH5paCb6A==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -5643,16 +5609,6 @@
         "lodash": "^4.17.13",
         "mkdirp": "^0.5.0",
         "propagate": "^2.0.0"
-      }
-    },
-    "node-environment-flags": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-      "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-      "dev": true,
-      "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
       }
     },
     "node-fetch": {
@@ -5835,40 +5791,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.0.3.tgz",
       "integrity": "sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg=="
-    },
-    "object-inspect": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
-      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
-      }
-    },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
-      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -6427,6 +6349,15 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
     },
+    "randombytes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.1.0"
+      }
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -6485,12 +6416,12 @@
       }
     },
     "readdirp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-      "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
+      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.0.4"
+        "picomatch": "^2.2.1"
       }
     },
     "redis-commands": {
@@ -6731,6 +6662,15 @@
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true
         }
+      }
+    },
+    "serialize-javascript": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-5.0.1.tgz",
+      "integrity": "sha512-SaaNal9imEO737H2c05Og0/8LUXG7EnsZyMa8MzkmuHoELfT6txuj0cMqRj6zfPKnmQ1yasR4PCJc8x+M4JSPA==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
@@ -7546,6 +7486,44 @@
         }
       }
     },
+    "sort-object-keys": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+      "integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg==",
+      "dev": true
+    },
+    "sort-package-json": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.46.1.tgz",
+      "integrity": "sha512-jUkuCxcXCZD31eIJ/Zza62LRP0lzd4LNkY0z0q1kDSvfBfCmPotrHPXVrz6WTppbGeM2JzNyyARQLUEnK4dUyg==",
+      "dev": true,
+      "requires": {
+        "detect-indent": "^6.0.0",
+        "detect-newline": "3.1.0",
+        "git-hooks-list": "1.0.3",
+        "globby": "10.0.0",
+        "is-plain-obj": "2.1.0",
+        "sort-object-keys": "^1.1.3"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "10.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+          "integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.0.3",
+            "glob": "^7.1.3",
+            "ignore": "^5.1.1",
+            "merge2": "^1.2.3",
+            "slash": "^3.0.0"
+          }
+        }
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7680,26 +7658,6 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
-      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
-      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -8354,6 +8312,12 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
     },
+    "workerpool": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.2.tgz",
+      "integrity": "sha512-DSNyvOpFKrNusaaUwk+ej6cBj1bmhLcBfj80elGk+ZIo5JSkq+unB1dLKEOcNfJDZgjGICfhQ0Q5TbP0PvF4+Q==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -8500,173 +8464,28 @@
       }
     },
     "yargs-unparser": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
           "dev": true
         },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "emoji-regex": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-          "dev": true
-        },
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "y18n": {
+        "decamelize": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
           "dev": true
-        },
-        "yargs": {
-          "version": "13.3.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-          "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-          "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,75 +1,51 @@
 {
   "name": "@commerce-apps/core",
   "version": "1.5.0",
-  "description": "Commerce SDK Generator, contains the templates to generate the SDK",
+  "description": "The Core package provides a variety of functions that make interacting with Salesforce Commerce APIs easy",
+  "homepage": "https://developer.commercecloud.com/s/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SalesforceCommerceCloud/commerce-sdk-core"
+  },
+  "license": "BSD-3-Clause",
+  "author": "",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "scripts": {
-    "depcheck": "depcheck",
-    "lint": "eslint . --ext .ts --fix",
-    "lint:ci": "eslint . --ext .ts --quiet",
-    "pretest": "npm run lint && npm run depcheck",
-    "pretest:ci": "npm run lint:ci && npm run depcheck",
-    "clean": "rm -rf package-lock.json && rm -rf dist",
-    "clean:node": "rm -rf node_modules",
-    "clean:all": "npm run clean && npm run clean:node",
-    "build": "tsc",
-    "test": "npm run cover:all",
-    "test:ci": "npm run pretest:ci && npm run cover:ci",
-    "test:unit": "mocha \"test/**/*.test.ts\"",
-    "test:unit:ci": "npm run test:unit -- --reporter=xunit --reporter-options output=./reports/unitTests.xml",
-    "test:integration": "mocha \"testIntegration/**/*.test.ts\"",
-    "test:integration:redis": "npm run redis && npm run test:integration && npm run redis:shutdown",
-    "test:integration:ci": "npm run test:integration -- --reporter=xunit --reporter-options output=./reports/integrationTests.xml",
-    "cover:all": "npm run cover:unit && npm run cover:integration && npm run cover:report",
-    "cover:unit": "nyc --silent npm run test:unit",
-    "cover:integration": "nyc --silent --no-clean npm run test:integration:redis",
-    "cover:report": "nyc report --reporter=lcov --reporter=text",
-    "cover:ci": "npm run cover:unit:ci && npm run cover:integration:ci && npm run cover:report",
-    "cover:unit:ci": "nyc --silent npm run test:unit:ci",
-    "cover:integration:ci": "nyc --silent --no-clean npm run test:integration",
-    "redis": "docker rm --force redis-commerce-sdk; docker run -dp 6379:6379 --name redis-commerce-sdk redis:5-alpine",
-    "redis:shutdown": "docker rm --force redis-commerce-sdk",
-    "redis:debug": "docker rm --force redis-commerce-sdk-debug; docker run -dp 6379:6379 --name redis-commerce-sdk-debug redis:5-alpine && docker exec -it redis-commerce-sdk-debug redis-cli monitor",
-    "redis:debug:shutdown": "docker rm --force redis-commerce-sdk-debug",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
-  },
   "files": [
     "dist",
     "README.md",
     "LICENSE.txt"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
-  "nyc": {
-    "extends": "@istanbuljs/nyc-config-typescript",
-    "include": [
-      "src/**/*.ts"
-    ],
-    "reporter": [
-      "lcov",
-      "text"
-    ],
-    "extension": [
-      ".ts"
-    ],
-    "all": true,
-    "check-coverage": true,
-    "branches": 80,
-    "functions": 80,
-    "lines": 80,
-    "statements": -10,
-    "per-file": true
-  },
-  "mocha": {
-    "forbidOnly": true,
-    "require": [
-      "source-map-support/register",
-      "ts-node/register"
-    ],
-    "colors": true
+  "scripts": {
+    "build": "tsc",
+    "clean": "rm -rf package-lock.json && rm -rf dist",
+    "clean:all": "npm run clean && npm run clean:node",
+    "clean:node": "rm -rf node_modules",
+    "cover:all": "npm run cover:unit && npm run cover:integration && npm run cover:report",
+    "cover:ci": "npm run cover:unit:ci && npm run cover:integration:ci && npm run cover:report",
+    "cover:integration": "nyc --silent --no-clean npm run test:integration:redis",
+    "cover:integration:ci": "nyc --silent --no-clean npm run test:integration",
+    "cover:report": "nyc report --reporter=lcov --reporter=text",
+    "cover:unit": "nyc --silent npm run test:unit",
+    "cover:unit:ci": "nyc --silent npm run test:unit:ci",
+    "depcheck": "depcheck",
+    "lint": "sort-package-json && eslint . --ext .ts --fix",
+    "lint:ci": "npm run lint -- --quiet",
+    "prepare": "npm run snyk-protect",
+    "redis": "docker rm --force redis-commerce-sdk; docker run -dp 6379:6379 --name redis-commerce-sdk redis:5-alpine",
+    "redis:debug": "docker rm --force redis-commerce-sdk-debug; docker run -dp 6379:6379 --name redis-commerce-sdk-debug redis:5-alpine && docker exec -it redis-commerce-sdk-debug redis-cli monitor",
+    "redis:debug:shutdown": "docker rm --force redis-commerce-sdk-debug",
+    "redis:shutdown": "docker rm --force redis-commerce-sdk",
+    "snyk-protect": "snyk protect",
+    "pretest": "npm run lint && npm run depcheck",
+    "test": "npm run cover:all",
+    "pretest:ci": "npm run lint:ci && npm run depcheck",
+    "test:ci": "npm run pretest:ci && npm run cover:ci",
+    "test:integration": "mocha \"testIntegration/**/*.test.ts\"",
+    "test:integration:ci": "npm run test:integration -- --reporter=xunit --reporter-options output=./reports/integrationTests.xml",
+    "test:integration:redis": "npm run redis && npm run test:integration && npm run redis:shutdown",
+    "test:unit": "mocha \"test/**/*.test.ts\"",
+    "test:unit:ci": "npm run test:unit -- --reporter=xunit --reporter-options output=./reports/unitTests.xml"
   },
   "lint-staged": {
     "*.js": [
@@ -77,44 +53,22 @@
       "git add"
     ]
   },
-  "eslintConfig": {
-    "parser": "@typescript-eslint/parser",
-    "extends": [
-      "plugin:@typescript-eslint/recommended",
-      "prettier/@typescript-eslint",
-      "plugin:prettier/recommended"
-    ],
-    "plugins": [
-      "@typescript-eslint",
-      "header"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2018,
-      "sourceType": "module"
-    },
-    "rules": {
-      "@typescript-eslint/interface-name-prefix": [
-        "error",
-        {
-          "prefixWithI": "always"
-        }
-      ],
-      "header/header": [
-        2,
-        "block",
-        [
-          "",
-          {
-            "pattern": "^ \\* Copyright \\(c\\) \\d{4}, salesforce.com, inc\\.$",
-            "template": " * Copyright (c) 2020, salesforce.com, inc."
-          },
-          " * All rights reserved.",
-          " * SPDX-License-Identifier: BSD-3-Clause",
-          " * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause",
-          " "
-        ]
-      ]
-    }
+  "dependencies": {
+    "@keyv/redis": "^2.1.1",
+    "dotenv": "~8.2.0",
+    "fetch-to-curl": "^0.4.0",
+    "ioredis": "^4.16.2",
+    "jsonwebtoken": "^8.5.1",
+    "keyv": "^4.0.0",
+    "lodash": "^4.17.20",
+    "loglevel": "^1.6.8",
+    "make-fetch-happen": "^8.0.4",
+    "minipass-fetch": "^1.2.1",
+    "qs": "~6.9.1",
+    "quick-lru": "^5.1.1",
+    "retry": "^0.12.0",
+    "snyk": "^1.399.0",
+    "ssri": "^7.1.0"
   },
   "devDependencies": {
     "@commerce-apps/raml-toolkit": "^0.4.2",
@@ -142,34 +96,19 @@
     "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-prettier": "^3.1.4",
     "lint-staged": "^10.1.3",
-    "mocha": "^7.0.1",
+    "mocha": "^8.2.1",
     "nock": "^11.7.0",
     "nyc": "^15.1.0",
     "prettier": "^2.0.5",
     "qs": "^6.9.0",
     "sinon": "^9.0.2",
+    "sort-package-json": "^1.46.1",
     "source-map-support": "^0.5.16",
     "ts-node": "^8.10.2"
   },
-  "author": "",
-  "license": "BSD-3-Clause",
-  "gitHead": "2a6031f5f57c4ba5df8bfb5c4ca42b2631befe58",
-  "dependencies": {
-    "@keyv/redis": "^2.1.1",
-    "dotenv": "~8.2.0",
-    "fetch-to-curl": "^0.4.0",
-    "ioredis": "^4.16.2",
-    "jsonwebtoken": "^8.5.1",
-    "keyv": "^4.0.0",
-    "lodash": "^4.17.20",
-    "loglevel": "^1.6.8",
-    "make-fetch-happen": "^8.0.4",
-    "minipass-fetch": "^1.2.1",
-    "qs": "~6.9.1",
-    "quick-lru": "^5.1.1",
-    "retry": "^0.12.0",
-    "snyk": "^1.399.0",
-    "ssri": "^7.1.0"
+  "publishConfig": {
+    "access": "public"
   },
+  "gitHead": "2a6031f5f57c4ba5df8bfb5c4ca42b2631befe58",
   "snyk": true
 }

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import sinon from "sinon";
+import { sdkLogger } from "../src";
+
+let consoleStub: sinon.SinonStub;
+let sdkLoggerInfoStub: sinon.SinonStub;
+let sdkLoggerDebugStub: sinon.SinonStub;
+
+beforeEach(() => {
+  consoleStub = sinon.stub(console, "log");
+  sdkLoggerInfoStub = sinon.stub(sdkLogger, "info");
+  sdkLoggerDebugStub = sinon.stub(sdkLogger, "debug");
+});
+
+afterEach(() => {
+  consoleStub.restore();
+  sdkLoggerInfoStub.restore();
+  sdkLoggerDebugStub.restore();
+});

--- a/test/staticClientFormatLog.test.ts
+++ b/test/staticClientFormatLog.test.ts
@@ -12,166 +12,176 @@ import fetchToCurl from "fetch-to-curl";
 
 import { logFetch, logResponse } from "../src/base/staticClient";
 import { sdkLogger } from "../src/base/sdkLogger";
+import { LogLevelDesc } from "loglevel";
 
-let logLevel;
-before(() => {
-  logLevel = sdkLogger.getLevel();
-});
-after(() => {
-  //reset log level
-  sdkLogger.setLevel(logLevel);
-});
+describe("Static Client format log tests", () => {
+  let stub: sinon.SinonStub;
+  let logLevel: LogLevelDesc;
 
-describe("Test info log messages of fetch data", () => {
-  let stub;
   before(() => {
-    sdkLogger.setLevel(sdkLogger.levels.INFO);
-    stub = sinon.stub(sdkLogger, "info");
+    logLevel = sdkLogger.getLevel();
   });
+
   after(() => {
-    sinon.reset();
-  });
-  it("formats basic get correctly", () => {
-    const resource = "https://example.com/my/endpoint";
-    const options = { method: "GET" };
-    const output = "Request: GET https://example.com/my/endpoint";
-    logFetch(resource, options);
-    sinon.assert.calledWith(stub, output);
+    //reset log level
+    sdkLogger.setLevel(logLevel);
   });
 
-  it("formats get with query params correctly", () => {
-    const resource = "https://example.com/my/endpoint?myparam=value";
-    const options = { method: "GET" };
-    const output = "Request: GET https://example.com/my/endpoint?myparam=value";
-    logFetch(resource, options);
-    sinon.assert.calledWith(stub, output);
+  beforeEach(() => sinon.restore());
+
+  afterEach(() => stub.restore());
+
+  describe("Test info log messages of fetch data", () => {
+    before(() => sdkLogger.setLevel(sdkLogger.levels.INFO));
+
+    beforeEach(() => {
+      stub = sinon.stub(sdkLogger, "info");
+    });
+
+    it("formats basic get correctly", () => {
+      const resource = "https://example.com/my/endpoint";
+      const options = { method: "GET" };
+      const output = "Request: GET https://example.com/my/endpoint";
+      logFetch(resource, options);
+      sinon.assert.calledWith(stub, output);
+    });
+
+    it("formats get with query params correctly", () => {
+      const resource = "https://example.com/my/endpoint?myparam=value";
+      const options = { method: "GET" };
+      const output =
+        "Request: GET https://example.com/my/endpoint?myparam=value";
+      logFetch(resource, options);
+      sinon.assert.calledWith(stub, output);
+    });
+
+    it("formats basic POST correctly", () => {
+      const resource = "https://example.com/my/endpoint";
+      const options = { method: "POST" };
+      const output = "Request: POST https://example.com/my/endpoint";
+      logFetch(resource, options);
+      sinon.assert.calledWith(stub, output);
+    });
   });
 
-  it("formats basic POST correctly", () => {
-    const resource = "https://example.com/my/endpoint";
-    const options = { method: "POST" };
-    const output = "Request: POST https://example.com/my/endpoint";
-    logFetch(resource, options);
-    sinon.assert.calledWith(stub, output);
-  });
-});
-
-function getDebugMsgForFetch(resource, options): string {
-  return `Fetch Options: ${JSON.stringify(
-    options,
-    null,
-    2
-  )}\nCurl: ${fetchToCurl(resource, options)}`;
-}
-describe("Test debug log messages of fetch data", () => {
-  let stub;
-  before(() => {
-    sdkLogger.setLevel(sdkLogger.levels.DEBUG);
-    sinon.stub(sdkLogger, "info");
-    stub = sinon.stub(sdkLogger, "debug");
-  });
-  after(() => {
-    sinon.reset();
-  });
-  it("formats basic get correctly", () => {
-    const resource = "https://example.com/my/endpoint";
-    const options = { method: "GET" };
-    logFetch(resource, options);
-    sinon.assert.calledWith(stub, getDebugMsgForFetch(resource, options));
-  });
-
-  it("formats get with query params correctly", () => {
-    const resource = "https://example.com/my/endpoint?myparam=value";
-    const options = { method: "GET" };
-    logFetch(resource, options);
-    sinon.assert.calledWith(stub, getDebugMsgForFetch(resource, options));
-  });
-
-  it("formats basic POST correctly", () => {
-    const resource = "https://example.com/my/endpoint";
-    const options = {
-      method: "POST",
-      body: JSON.stringify({ key1: "value1" }),
-    };
-    logFetch(resource, options);
-    sinon.assert.calledWith(stub, getDebugMsgForFetch(resource, options));
-  });
-});
-
-describe("Test info log messages of response data", () => {
-  let stub;
-  before(() => {
-    sdkLogger.setLevel(sdkLogger.levels.INFO);
-    stub = sinon.stub(sdkLogger, "info");
-  });
-  after(() => {
-    sinon.reset();
-  });
-  it("formats success response correctly", () => {
-    const response: Response = new Response(
-      {},
-      { status: 200, statusText: "Everything is ok" }
-    );
-    const output = "Response: successful 200 Everything is ok";
-    logResponse(response);
-    sinon.assert.calledWith(stub, output);
-  });
-
-  it("formats created response correctly", () => {
-    const response: Response = new Response(
-      {},
-      { status: 201, statusText: "Everything is created" }
-    );
-    const output = "Response: successful 201 Everything is created";
-    logResponse(response);
-    sinon.assert.calledWith(stub, output);
-  });
-
-  it("formats not modified response correctly", () => {
-    const response: Response = new Response(
-      {},
-      { status: 304, statusText: "Everything is the same" }
-    );
-    const output = "Response: successful 304 Everything is the same";
-    logResponse(response);
-    sinon.assert.calledWith(stub, output);
-  });
-
-  it("formats 404 response correctly", () => {
-    const response: Response = new Response(
-      {},
-      { status: 404, statusText: "Everything is gone" }
-    );
-    const output = "Response: unsuccessful 404 Everything is gone";
-    logResponse(response);
-    sinon.assert.calledWith(stub, output);
-  });
-});
-
-describe("Test debug log messages of response data", () => {
-  let stub;
-  before(() => {
-    sdkLogger.setLevel(sdkLogger.levels.DEBUG);
-    sinon.stub(sdkLogger, "info");
-    stub = sinon.stub(sdkLogger, "debug");
-  });
-  after(() => {
-    sinon.reset();
-  });
-  it("formats response with headers correctly", () => {
-    const respHeaders = new Headers();
-    respHeaders.append("Content-Type", "application/json");
-    const response: Response = new Response(
-      {},
-      { status: 200, statusText: "Everything is ok", headers: respHeaders }
-    );
-
-    const output = `Response Headers: ${JSON.stringify(
-      respHeaders.raw(),
+  function getDebugMsgForFetch(resource, options): string {
+    return `Fetch Options: ${JSON.stringify(
+      options,
       null,
       2
-    )}`;
-    logResponse(response);
-    sinon.assert.calledWith(stub, output);
+    )}\nCurl: ${fetchToCurl(resource, options)}`;
+  }
+
+  describe("Test debug log messages of fetch data", () => {
+    let stub: sinon.SinonStub;
+
+    before(() => sdkLogger.setLevel(sdkLogger.levels.DEBUG));
+
+    beforeEach(() => {
+      sinon.stub(sdkLogger, "info");
+      stub = sinon.stub(sdkLogger, "debug");
+    });
+
+    it("formats basic get correctly", () => {
+      const resource = "https://example.com/my/endpoint";
+      const options = { method: "GET" };
+      logFetch(resource, options);
+      sinon.assert.calledWith(stub, getDebugMsgForFetch(resource, options));
+    });
+
+    it("formats get with query params correctly", () => {
+      const resource = "https://example.com/my/endpoint?myparam=value";
+      const options = { method: "GET" };
+      logFetch(resource, options);
+      sinon.assert.calledWith(stub, getDebugMsgForFetch(resource, options));
+    });
+
+    it("formats basic POST correctly", () => {
+      const resource = "https://example.com/my/endpoint";
+      const options = {
+        method: "POST",
+        body: JSON.stringify({ key1: "value1" }),
+      };
+      logFetch(resource, options);
+      sinon.assert.calledWith(stub, getDebugMsgForFetch(resource, options));
+    });
+  });
+
+  describe("Test info log messages of response data", () => {
+    let stub: sinon.SinonStub;
+
+    before(() => sdkLogger.setLevel(sdkLogger.levels.INFO));
+
+    beforeEach(() => {
+      stub = sinon.stub(sdkLogger, "info");
+      sinon.stub(sdkLogger, "debug");
+    });
+
+    it("formats success response correctly", () => {
+      const response: Response = new Response(
+        {},
+        { status: 200, statusText: "Everything is ok" }
+      );
+      const output = "Response: successful 200 Everything is ok";
+      logResponse(response);
+      sinon.assert.calledWith(stub, output);
+    });
+
+    it("formats created response correctly", () => {
+      const response: Response = new Response(
+        {},
+        { status: 201, statusText: "Everything is created" }
+      );
+      const output = "Response: successful 201 Everything is created";
+      logResponse(response);
+      sinon.assert.calledWith(stub, output);
+    });
+
+    it("formats not modified response correctly", () => {
+      const response: Response = new Response(
+        {},
+        { status: 304, statusText: "Everything is the same" }
+      );
+      const output = "Response: successful 304 Everything is the same";
+      logResponse(response);
+      sinon.assert.calledWith(stub, output);
+    });
+
+    it("formats 404 response correctly", () => {
+      const response: Response = new Response(
+        {},
+        { status: 404, statusText: "Everything is gone" }
+      );
+      const output = "Response: unsuccessful 404 Everything is gone";
+      logResponse(response);
+      sinon.assert.calledWith(stub, output);
+    });
+  });
+
+  describe("Test debug log messages of response data", () => {
+    let stub: sinon.SinonStub;
+
+    before(() => sdkLogger.setLevel(sdkLogger.levels.DEBUG));
+
+    beforeEach(() => {
+      stub = sinon.stub(sdkLogger, "debug");
+    });
+
+    it("formats response with headers correctly", () => {
+      const respHeaders = new Headers();
+      respHeaders.append("Content-Type", "application/json");
+      const response: Response = new Response(
+        {},
+        { status: 200, statusText: "Everything is ok", headers: respHeaders }
+      );
+
+      const output = `Response Headers: ${JSON.stringify(
+        respHeaders.raw(),
+        null,
+        2
+      )}`;
+      logResponse(response);
+      sinon.assert.calledWith(stub, output);
+    });
   });
 });


### PR DESCRIPTION
- Add a setup file that contains mocha root hooks that stub console.log, sdkLogger.info and sdkLogger.debug
- Update mocha to 8.2.1
- Extract mocha, nyc and eslint configs to their own separate files
- Update repo details in package.json
- Add sort-package-json, which we use in other repos to sort package.json
- Wrap staticClientFormatLog.test.ts tests in a top level describe block and extract any duplicate hooks to it