### PR TITLE
Restore logger tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2380,12 +2380,6 @@
             "@babel/runtime-corejs3": "^7.8.3"
           }
         },
-        "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
-          "dev": true
-        },
         "yargs": {
           "version": "15.4.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.0.tgz",
@@ -5466,9 +5460,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
@@ -5770,9 +5764,9 @@
           }
         },
         "y18n": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
           "dev": true
         },
         "yargs": {
@@ -8481,6 +8475,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
     },
     "yallist": {
       "version": "4.0.0",

--- a/test/sdkLogger.test.ts
+++ b/test/sdkLogger.test.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+import { expect } from "chai";
+import log from "loglevel";
+import { sdkLogger, COMMERCE_SDK_LOGGER_KEY } from "../src";
+
+describe("Logger utility", () => {
+  let logLevel: log.LogLevelDesc;
+
+  before(() => {
+    logLevel = sdkLogger.getLevel();
+  });
+
+  after(() => {
+    // Restore original log level
+    sdkLogger.setLevel(logLevel);
+  });
+
+  it("is accessible via loglevel interface", async () => {
+    expect(log.getLogger(COMMERCE_SDK_LOGGER_KEY)).to.equal(sdkLogger);
+  });
+
+  it("defaults to WARN log level", async () => {
+    expect(sdkLogger.getLevel()).to.equal(log.levels.WARN);
+  });
+
+  it("can have log level changed", async () => {
+    sdkLogger.setLevel(sdkLogger.levels.DEBUG);
+    expect(sdkLogger.getLevel()).to.equal(log.levels.DEBUG);
+  });
+});


### PR DESCRIPTION
They were accidentally removed in #1. This restores them. Also `npm audit fix`, just for funsies.