### PR TITLE
Support boolean query parameters

### DIFF
--- a/src/base/resource.ts
+++ b/src/base/resource.ts
@@ -11,7 +11,7 @@ export type BaseUriParameters = Record<string, string>;
 export type PathParameters = Record<string, string>;
 export type QueryParameters = Record<
   string,
-  string | number | string[] | number[]
+  boolean | string | number | string[] | number[]
 >;
 
 /**

--- a/test/resource.test.ts
+++ b/test/resource.test.ts
@@ -169,4 +169,18 @@ describe("Resource class tests", () => {
       "baseUri/path/id1/and/id2?firstQueryParam=v1&second-query-param=value%202"
     );
   });
+
+  it("returns correct url with boolean query parameter set to true", () => {
+    assert.strictEqual(
+      new Resource("baseUri", {}, "/path", {}, { bool: true }).toString(),
+      "baseUri/path?bool=true"
+    );
+  });
+
+  it("returns correct url with boolean query parameter set to false", () => {
+    assert.strictEqual(
+      new Resource("baseUri", {}, "/path", {}, { bool: false }).toString(),
+      "baseUri/path?bool=false"
+    );
+  });
 });


### PR DESCRIPTION
The next version of the Shopper Baskets API will use boolean query parameters. This PR updates our type definition to allow that.