### PR TITLE
Release v1.6.1 @W-14129454@

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.6.1
+
+* Arrays passed as query parameters follow the comma separated format except for the `refine` query parameter which follows the repeated format
+
 ## 1.6.0
 
 * Fetch options are able to be passed on the client configuration level as well as on a per call basis

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commerce-apps/core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "The Core package provides a variety of functions that make interacting with Salesforce Commerce APIs easy",
   "homepage": "https://developer.salesforce.com/docs/commerce/commerce-api/overview",
   "repository": {


### PR DESCRIPTION
This PR releases `v1.6.1` which ensures that arrays passed as query parameters follow the comma separated format except for the `refine` query parameter which follows the repeated format