### PR TITLE
Feat: Add support for custom APIs @W-15585881@

### DIFF
--- a/src/base/client.ts
+++ b/src/base/client.ts
@@ -10,7 +10,7 @@ import { config } from "dotenv";
 import { OperationOptions } from "retry";
 import type { RequestInit } from "node-fetch";
 
-import { CommonParameters, CustomApiParameters } from "./commonParameters";
+import { CommonParameters } from "./commonParameters";
 import { ICacheManager } from "./cacheManager";
 import { CacheManagerKeyv } from "./cacheManagerKeyv";
 import { BasicHeaders } from "./resource";
@@ -26,11 +26,12 @@ config();
  *
  * @class ClientConfig
  */
-export class ClientConfig {
+export class ClientConfig<Params extends CommonParameters = CommonParameters> {
   public baseUri?: string;
   public cacheManager?: ICacheManager;
   public headers?: BasicHeaders;
-  public parameters?: CommonParameters & CustomApiParameters;
+  // Params defaults to CommonParameters
+  public parameters?: Params;
   public retrySettings?: OperationOptions;
   public fetchOptions?: RequestInit;
 }

--- a/src/base/client.ts
+++ b/src/base/client.ts
@@ -10,7 +10,7 @@ import { config } from "dotenv";
 import { OperationOptions } from "retry";
 import type { RequestInit } from "node-fetch";
 
-import { CommonParameters } from "./commonParameters";
+import { CommonParameters, CustomApiParameters } from "./commonParameters";
 import { ICacheManager } from "./cacheManager";
 import { CacheManagerKeyv } from "./cacheManagerKeyv";
 import { BasicHeaders } from "./resource";
@@ -30,7 +30,7 @@ export class ClientConfig {
   public baseUri?: string;
   public cacheManager?: ICacheManager;
   public headers?: BasicHeaders;
-  public parameters?: CommonParameters;
+  public parameters?: CommonParameters & CustomApiParameters;
   public retrySettings?: OperationOptions;
   public fetchOptions?: RequestInit;
 }

--- a/src/base/commonParameters.ts
+++ b/src/base/commonParameters.ts
@@ -22,9 +22,3 @@ export type CommonParameters = {
   siteId?: string;
   version?: string;
 };
-
-export type CustomApiParameters = {
-  endpointName?: string;
-  apiName?: string;
-  apiVersion?: string;
-};

--- a/src/base/commonParameters.ts
+++ b/src/base/commonParameters.ts
@@ -22,3 +22,9 @@ export type CommonParameters = {
   siteId?: string;
   version?: string;
 };
+
+export type CustomApiParameters = {
+  endpointName?: string;
+  apiName?: string;
+  apiVersion?: string;
+}

--- a/src/base/commonParameters.ts
+++ b/src/base/commonParameters.ts
@@ -27,4 +27,4 @@ export type CustomApiParameters = {
   endpointName?: string;
   apiName?: string;
   apiVersion?: string;
-}
+};

--- a/src/base/staticClient.ts
+++ b/src/base/staticClient.ts
@@ -218,8 +218,10 @@ export async function runFetch(
     },
   };
 
-  if (typeof options.body !== "undefined" && !options.disableTransformBody) {
-    fetchOptions.body = transformRequestBody(options.body, fetchOptions);
+  if (typeof options.body !== "undefined") {
+    fetchOptions.body = options.disableTransformBody
+      ? (options.body as BodyInit)
+      : transformRequestBody(options.body, fetchOptions);
   }
 
   logFetch(resource, fetchOptions);

--- a/src/base/staticClient.ts
+++ b/src/base/staticClient.ts
@@ -34,6 +34,7 @@ export type SdkFetchOptions = {
   rawResponse?: boolean;
   retrySettings?: OperationOptions;
   fetchOptions?: RequestInit;
+  disableTransformBody?: boolean;
   body?: unknown;
 };
 
@@ -217,7 +218,7 @@ export async function runFetch(
     },
   };
 
-  if (typeof options.body !== "undefined") {
+  if (typeof options.body !== "undefined" && !options.disableTransformBody) {
     fetchOptions.body = transformRequestBody(options.body, fetchOptions);
   }
 

--- a/src/base/staticClient.ts
+++ b/src/base/staticClient.ts
@@ -175,7 +175,7 @@ export const transformRequestBody = (
  * @returns Either the Response object or the DTO inside it wrapped in a promise,
  * depending upon options.rawResponse
  */
-async function runFetch(
+export async function runFetch(
   method: "delete" | "get" | "patch" | "post" | "put",
   options: SdkFetchOptions
 ): Promise<object> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export {
   ResponseError,
 } from "./base/client";
 
-import { _get, _delete, _patch, _post, _put } from "./base/staticClient";
+import { _get, _delete, _patch, _post, _put, runFetch } from "./base/staticClient";
 
 export {
   getObjectFromResponse,
@@ -26,6 +26,7 @@ export const StaticClient = {
   patch: _patch,
   post: _post,
   put: _put,
+  runFetch,
 };
 
 export { IAuthToken, ShopperToken, stripBearer } from "./base/authHelper";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,14 @@ export {
   ResponseError,
 } from "./base/client";
 
-import { _get, _delete, _patch, _post, _put, runFetch } from "./base/staticClient";
+import {
+  _get,
+  _delete,
+  _patch,
+  _post,
+  _put,
+  runFetch,
+} from "./base/staticClient";
 
 export {
   getObjectFromResponse,


### PR DESCRIPTION
This PR adds support for custom APIs that will be consumed by `commerce-sdk`. The updates include adding a new type for custom APIs and exposing an underlying helper function. This PR will need to be merged and `commerce-sdk-core` will need to be released before being consumed by the `commerce-sdk`. The main changes in this PR are:

1. adding a flag for disabling request body transformation based on content-type header (enabled by default)
2. allowing a generic type to be passed for `clientConfig` for parameters

Companion PR: https://github.com/SalesforceCommerceCloud/commerce-sdk/pull/402/files