### PR TITLE
Update: Make body optional for API calls (@W-18130788@)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 1.8.0
+* Make request `body` for HTTP endpoint calls optional [#117](https://github.com/SalesforceCommerceCloud/commerce-sdk-core/pull/117/files)
+
 ## 1.7.0
 
 * Expose underlying helper function for fetch calls [#110](https://github.com/SalesforceCommerceCloud/commerce-sdk-core/pull/110)

--- a/src/base/staticClient.ts
+++ b/src/base/staticClient.ts
@@ -239,7 +239,7 @@ export async function runFetch(
  * @returns Either the Response object or the DTO inside it wrapped in a promise,
  * depending upon options.rawResponse
  */
-export async function _get(options: SdkFetchOptionsNoBody): Promise<object> {
+export async function _get(options: SdkFetchOptions): Promise<object> {
   return runFetch("get", options);
 }
 
@@ -251,7 +251,7 @@ export async function _get(options: SdkFetchOptionsNoBody): Promise<object> {
  * @returns Either the Response object or the DTO inside it wrapped in a promise,
  * depending upon options.rawResponse
  */
-export async function _delete(options: SdkFetchOptionsNoBody): Promise<object> {
+export async function _delete(options: SdkFetchOptions): Promise<object> {
   return runFetch("delete", options);
 }
 
@@ -264,7 +264,7 @@ export async function _delete(options: SdkFetchOptionsNoBody): Promise<object> {
  * depending upon options.rawResponse
  */
 export async function _patch(
-  options: SdkFetchOptionsWithBody
+  options: SdkFetchOptions
 ): Promise<object> {
   return runFetch("patch", options);
 }
@@ -277,7 +277,7 @@ export async function _patch(
  * @returns Either the Response object or the DTO inside it wrapped in a promise,
  * depending upon options.rawResponse
  */
-export async function _post(options: SdkFetchOptionsWithBody): Promise<object> {
+export async function _post(options: SdkFetchOptions): Promise<object> {
   return runFetch("post", options);
 }
 
@@ -289,6 +289,6 @@ export async function _post(options: SdkFetchOptionsWithBody): Promise<object> {
  * @returns Either the Response object or the DTO inside it wrapped in a promise,
  * depending upon options.rawResponse
  */
-export async function _put(options: SdkFetchOptionsWithBody): Promise<object> {
+export async function _put(options: SdkFetchOptions): Promise<object> {
   return runFetch("put", options);
 }


### PR DESCRIPTION
In the new OAS node SDK, if the function does not include a body, we do not generate a default body, so we need to update our fetch implementation to make the request body optional as certain `patch`/`put`/`post` endpoints do not require a body. 

The pre-existing `SDKFetchOptions` type makes body optional:

```
export declare type SdkFetchOptions = {
    client: BaseClient;
    path: string;
    pathParameters?: PathParameters;
    queryParameters?: QueryParameters;
    headers?: BasicHeaders;
    rawResponse?: boolean;
    retrySettings?: OperationOptions;
    fetchOptions?: RequestInit;
    disableTransformBody?: boolean;
    body?: unknown;
};
```